### PR TITLE
Refactor/mail controller

### DIFF
--- a/src/main/java/com/project/tripmate/config/SecurityConfig.java
+++ b/src/main/java/com/project/tripmate/config/SecurityConfig.java
@@ -54,9 +54,9 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**").permitAll()
-                        .requestMatchers("/login", "/auth/login", "/user/signup", "/user/verify/**", "/tourAPI/**")
+                        .requestMatchers("/login", "/auth/login", "/user/signup", "/tourAPI/**")
                         .permitAll()
-                        .requestMatchers(HttpMethod.GET, "/course/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/course/**", "/mail/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .formLogin(AbstractAuthenticationFilterConfigurer::permitAll)

--- a/src/main/java/com/project/tripmate/global/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/tripmate/global/GlobalExceptionHandler.java
@@ -41,20 +41,6 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(response);
     }
 
-    // 이메일 전송 관련 예외 처리 (MessagingException)
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "500", description = "이메일 전송에 실패했습니다.")
-    })
-    @ExceptionHandler(MessagingException.class)
-    public ResponseEntity<JsonResponse> handleMessagingException(MessagingException ex) {
-        JsonResponse response = new JsonResponse(
-                HttpStatus.INTERNAL_SERVER_ERROR.value(),
-                ex.getMessage(),
-                null
-        );
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
-    }
-
     // 모든 예외 처리 (예상하지 못한 예외 처리)
     @ApiResponses(value = {
             @ApiResponse(responseCode = "500", description = "서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.")

--- a/src/main/java/com/project/tripmate/global/mail/MailController.java
+++ b/src/main/java/com/project/tripmate/global/mail/MailController.java
@@ -1,0 +1,61 @@
+package com.project.tripmate.global.mail;
+
+import com.project.tripmate.global.JsonResponse;
+import com.project.tripmate.user.dto.UserResponseDTO;
+import com.project.tripmate.user.service.UserService;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.mail.MessagingException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/mail")
+@RequiredArgsConstructor
+public class MailController {
+
+    private final MailService mailService;
+    private final UserService userService;
+
+    @PostMapping("/send")
+    public ResponseEntity<JsonResponse<MailRequestDTO>> sendEmail(@RequestBody MailRequestDTO mailRequestDTO) throws MessagingException {
+        mailService.sendEmail(mailRequestDTO.getTo(), mailRequestDTO.getVerificationUrl(), mailRequestDTO.getSubject());
+        JsonResponse<MailRequestDTO> response = new JsonResponse<>(
+                HttpStatus.OK.value(),
+                "이메일 전송이 완료되었습니다.",
+                mailRequestDTO);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/verify/{token}")
+    public ResponseEntity<JsonResponse<UserResponseDTO>> verifyEmailForUser(@PathVariable("token") String token) {
+        UserResponseDTO userResponseDTO = userService.verifyEmailForUser(token);
+        JsonResponse<UserResponseDTO> response = new JsonResponse<>(
+                HttpStatus.OK.value(),
+                "이메일 인증이 완료되었습니다.",
+                userResponseDTO);
+        return ResponseEntity.ok(response);
+    }
+
+    // 이메일 전송 관련 예외 처리 (MessagingException)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "500", description = "이메일 전송에 실패했습니다.")
+    })
+    @ExceptionHandler(MessagingException.class)
+    public ResponseEntity<JsonResponse> handleMessagingException(MessagingException ex) {
+        JsonResponse response = new JsonResponse(
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                ex.getMessage(),
+                null
+        );
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    }
+}

--- a/src/main/java/com/project/tripmate/global/mail/MailRequestDTO.java
+++ b/src/main/java/com/project/tripmate/global/mail/MailRequestDTO.java
@@ -1,0 +1,29 @@
+package com.project.tripmate.global.mail;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class MailRequestDTO {
+
+    @NotBlank(message = "이메일을 입력해주세요")
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    private final String to;
+
+    private final String verificationUrl;
+    private final String subject;
+
+    @JsonCreator
+    public MailRequestDTO(
+            @JsonProperty("to") String to,
+            @JsonProperty("verificationUrl") String verificationUrl,
+            @JsonProperty("subject") String subject
+    ) {
+        this.to = to;
+        this.verificationUrl = verificationUrl;
+        this.subject = subject;
+    }
+}

--- a/src/main/java/com/project/tripmate/global/mail/MailService.java
+++ b/src/main/java/com/project/tripmate/global/mail/MailService.java
@@ -10,18 +10,22 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class MailService {
-    private final JavaMailSender javaMailSender;
 
-    public void sendEmail(String to, String verificationUrl, String subject) throws MessagingException {
+    private final JavaMailSender javaMailSender;
+    private static final String VERIFICATION_URL = "http://localhost:9090/mail/verify/";
+
+    public void sendEmail(String to, String verificationToken, String subject) throws MessagingException {
         MimeMessage message = javaMailSender.createMimeMessage();
         MimeMessageHelper helper = new MimeMessageHelper(message, true);
 
         helper.setTo(to);
         helper.setSubject(subject);
 
+        String verificationUrlWithToken =  VERIFICATION_URL + verificationToken;
+
         // HTML 내용 작성
         String htmlContent = "<p>이메일 인증을 완료하려면 아래 링크를 클릭하세요:</p>"
-                + "<a href=\"" + verificationUrl + "\">" + verificationUrl + "</a>";
+                + "<a href=\"" + verificationUrlWithToken + "\">" + verificationUrlWithToken + "</a>";
 
         helper.setText(htmlContent, true); // HTML 형식으로 전송
 

--- a/src/main/java/com/project/tripmate/user/controller/UserController.java
+++ b/src/main/java/com/project/tripmate/user/controller/UserController.java
@@ -68,26 +68,6 @@ public class UserController {
         return ResponseEntity.ok().body(response);
     }
 
-    // 이메일 인증
-    @GetMapping("/verify/{token}")
-    public ResponseEntity<JsonResponse<UserResponseDTO>> verifyEmail(@PathVariable String token) {
-        UserResponseDTO userResponseDTO = userService.verifyEmail(token);
-        JsonResponse<UserResponseDTO> response = new JsonResponse<>(
-                HttpStatus.OK.value(),
-                "이메일 인증이 완료되었습니다.",
-                userResponseDTO);
-        return ResponseEntity.ok(response);
-    }
-
-    // 사용자를 찾을 수 없을 때 발생하는 예외 처리
-    @ExceptionHandler(UserNotFoundException.class)
-    public ResponseEntity<JsonResponse<UserResponseDTO>> handleUserNotFoundException(UserNotFoundException ex) {
-        JsonResponse<UserResponseDTO> response = new JsonResponse<>(
-                HttpStatus.NOT_FOUND.value(),
-                ex.getMessage(),
-                null);
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
-    }
 
     // 이미 존재하는 이메일로 회원가입을 시도할 때 발생하는 예외 처리
     @ApiResponses(value = {
@@ -101,5 +81,15 @@ public class UserController {
                 null
         );
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    // 사용자를 찾을 수 없을 때 발생하는 예외 처리
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<JsonResponse<UserResponseDTO>> handleUserNotFoundException(UserNotFoundException ex) {
+        JsonResponse<UserResponseDTO> response = new JsonResponse<>(
+                HttpStatus.NOT_FOUND.value(),
+                ex.getMessage(),
+                null);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
     }
 }

--- a/src/main/java/com/project/tripmate/user/service/UserService.java
+++ b/src/main/java/com/project/tripmate/user/service/UserService.java
@@ -10,7 +10,6 @@ import com.project.tripmate.user.repository.UserRepository;
 import jakarta.mail.MessagingException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -28,20 +27,16 @@ public class UserService {
     // 회원 가입
     public UserResponseDTO signUp(UserRequestDTO userRequestDTO) throws MessagingException {
         validateEmail(userRequestDTO.getEmail()); // 이메일 중복 체크
-
         String encodedPassword = encodePassword(userRequestDTO.getPassword());
         String verificationToken = UUID.randomUUID().toString();
-
         User user = createUser(userRequestDTO, encodedPassword, verificationToken);
-
         sendEmail(user.getEmail(), verificationToken, "회원가입 이메일 인증");
-
         userRepository.save(user);
         return UserResponseDTO.from(user);
     }
 
     // 이메일 검증
-    public UserResponseDTO verifyEmail(String token) {
+    public UserResponseDTO verifyEmailForUser(String token) {
         User user = findUserByVerificationToken(token);
         user.enableAccount(); // 엔티티 메서드 사용
         userRepository.save(user);
@@ -104,8 +99,7 @@ public class UserService {
 
     // 이메일 전송 메서드
     private void sendEmail(String email, String verificationToken, String subject) throws MessagingException {
-        String verificationUrl = "http://tripmate-be.shop/user/verify/" + verificationToken;
-        mailService.sendEmail(email, verificationUrl, subject);
+        mailService.sendEmail(email, verificationToken, subject);
     }
 
     // 토큰을 사용하여 사용자 조회


### PR DESCRIPTION
## Pull Request 요약

`Mail` 관련 기능 리팩토링

### 변경 사항

- `MailController` 클래스 생성 후 기존에 `UserController`에 있던 이메일 전송/인증 메서드 이동
- `UserService`의 이메일 관련 메서드 이름 변경
- 전반적인 코드 리팩토링을 통해 `Mail` 관련 메서드의 활용성 증가

### 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 링크해주세요. 예) Resolves #123 -->

### 변경된 동작

이메일 인증 전송 링크가 `/user/verify/`에서 `/mail/verify/`로 변경됨

### 테스트 방법

![image](https://github.com/user-attachments/assets/02d4a5d2-6f43-4d2f-9227-60f97dc5db3a)


### 기타 정보

<!-- 추가적으로 전달할 정보가 있다면 여기에 작성해주세요 -->
